### PR TITLE
Done state

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,48 +2,29 @@
 
 
 [[projects]]
-  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = ""
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:711eebe744c0151a9d09af2315f0bb729b2ec7637ef4c410fa90a18ef74b65b6"
-  name = "github.com/stretchr/objx"
-  packages = ["."]
-  pruneopts = ""
-  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
-  version = "v0.1.1"
-
-[[projects]]
-  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
   name = "github.com/stretchr/testify"
   packages = [
-    ".",
     "assert",
-    "http",
-    "mock",
+    "require"
   ]
-  pruneopts = ""
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/stretchr/testify",
-    "github.com/stretchr/testify/assert",
-  ]
+  inputs-digest = "330034fc292a05167eb84d24ae8e15ac837339213016ba6e8748182b11c1c2d5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/analyticspipeline/analyticspipeline.go
+++ b/analyticspipeline/analyticspipeline.go
@@ -33,6 +33,7 @@ var (
 type Payload struct {
 	Current    map[string]interface{}   `json:"current"`
 	Remanining []map[string]interface{} `json:"remaining"`
+	Done       bool                     `json:"done"`
 }
 
 // PrintPayload prints a passed in Payload
@@ -261,6 +262,8 @@ func AnalyticsWorker(configStruct interface{}) (*Payload, error) {
 	if len(analyticsPayload.Remanining) > 0 {
 		result.Current = analyticsPayload.Remanining[0]
 		result.Remanining = analyticsPayload.Remanining[1:]
+	} else {
+		result.Done = true
 	}
 
 	return &result, nil

--- a/analyticspipeline/analyticspipeline_test.go
+++ b/analyticspipeline/analyticspipeline_test.go
@@ -31,6 +31,7 @@ func TestAnalyticsWorker(t *testing.T) {
 		collection   string
 		newCurrent   []byte
 		newRemaining []byte
+		newDone      bool
 	}{
 		{
 			context:      "normal case w/ flags",
@@ -38,6 +39,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			district:     expectedDistrict,
 			newCurrent:   emptyCurrent,
 			newRemaining: emptyRemaining,
+			newDone:      true,
 		},
 		{
 			context: "missing required field",
@@ -54,6 +56,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			district:     expectedDistrict,
 			newCurrent:   emptyCurrent,
 			newRemaining: emptyRemaining,
+			newDone:      true,
 		},
 		{
 			context:      "unwrapped json",
@@ -61,6 +64,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			district:     expectedDistrict,
 			newCurrent:   emptyCurrent,
 			newRemaining: emptyRemaining,
+			newDone:      true,
 		},
 		{
 			context:      "json w/ all fields",
@@ -69,6 +73,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			collection:   expectedCollection,
 			newCurrent:   emptyCurrent,
 			newRemaining: emptyRemaining,
+			newDone:      false,
 		},
 		{
 			context:      "json w/ remaining",
@@ -77,6 +82,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			collection:   expectedCollection,
 			newCurrent:   []byte("{\"district_id\":\"abc456\"}"),
 			newRemaining: emptyRemaining,
+			newDone:      false,
 		},
 		{
 			context:      "json w/ remaining array",
@@ -85,6 +91,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			collection:   expectedCollection,
 			newCurrent:   []byte("{\"district_id\":\"abc456\"}"),
 			newRemaining: []byte("[{\"district_id\":\"abc789\"}]"),
+			newDone:      false,
 		},
 		{
 			context: "empty JSON blob",
@@ -126,6 +133,7 @@ func TestAnalyticsWorker(t *testing.T) {
 			retrievedRemaining, err := json.Marshal(newPayload.Remanining)
 			assert.NoError(t, err, "Case '%s'", spec.context)
 			assert.Equal(t, spec.newRemaining, retrievedRemaining)
+			assert.Equal(t, spec.newDone, newPayload.Done)
 		} else {
 			assert.Equal(t, spec.err, err, "Case '%s'", spec.context)
 		}


### PR DESCRIPTION
I added a choice state to optionally fire off p4a-post-processing of the `mongo-to-redshift` workflow but I ran into some challenges:
1) To avoid having to update every single cron job payload I made an optional p4a-specific flag to trigger a choice state in workflows
2) because there is no `NULL`/`exists` check in AWS choice states, we need to have an always-present boolean

See failing job here:
https://production--hubble.int.clever.com/mongo-to-redshift:master/workflows/w/ff31414f-c549-48e9-af50-d4da0afc81e0/jobs

This always-set boolean will allow us to easier use the choice state for p4a's post-processing. 

- [x] Updated VERSION file.

Will bump s3-to-redshift after this merges